### PR TITLE
Command line option -o for overwrite now works also together with -W

### DIFF
--- a/include/report_manager.h
+++ b/include/report_manager.h
@@ -84,7 +84,7 @@ void reportSetTimeoutOccurred(reportStructure *report);
 void reportStructureFinalize(reportStructure *report);
 void printStats(reportStructure *report, FILE *stream, uint8_t confidenceIntervalsMask);
 int printStatsCSV(struct options *opts, reportStructure *report, const char *filename);
-int openTfile(const char *Tfilename,int followup_on_flag, char enabled_extra_data);
+int openTfile(const char *Tfilename, uint8_t overwrite, int followup_on_flag, char enabled_extra_data);
 int writeToTFile(int Tfiledescriptor,int decimal_digits,perPackerDataStructure *perPktData);
 void closeTfile(int Tfilepointer);
 

--- a/src/options.c
+++ b/src/options.c
@@ -1086,8 +1086,8 @@ unsigned int parse_options(int argc, char **argv, struct options *options) {
 		print_short_info_err(options);
 	}
 
-	if(options->overwrite==1 && options->filename==NULL) {
-		fprintf(stderr,"Error: '-o' (overwrite mode) can be specified only when the output to a file (with -f) is requested.\n");
+	if(options->overwrite==1 && options->filename==NULL && options->Wfilename==NULL) {
+		fprintf(stderr,"Error: '-o' (overwrite mode) can be specified only when the output to a file (with -f or -W) is requested.\n");
 		print_short_info_err(options);
 	}
 

--- a/src/qpid_proton/qpid_proton_consumer.c
+++ b/src/qpid_proton/qpid_proton_consumer.c
@@ -371,7 +371,7 @@ static int consumerEventHandler(struct amqp_data *aData,struct options *opts,rep
 							if(opts->Wfilename!=NULL) {
 								// No follow-up is supported for AMQP 1.0 testing, but, instead of passing just '0' to openTfile() it can be useful to keep
 								//  the check for a possible follow-up mode, as it may be implemented in some way in the future
-								aData->Wfiledescriptor=openTfile(opts->Wfilename,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
+								aData->Wfiledescriptor=openTfile(opts->Wfilename,opts->overwrite,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
 
 								// Already set some fields in the per-packet data structure, which won't change during the whole test
 								aData->perPktData.followup_on_flag=opts->followup_mode!=FOLLOWUP_OFF;

--- a/src/report_manager.c
+++ b/src/report_manager.c
@@ -468,7 +468,7 @@ int printStatsCSV(struct options *opts, reportStructure *report, const char *fil
 	return printOpErrStatus;
 }
 
-int openTfile(const char *Tfilename,int followup_on_flag, char enabled_extra_data) {
+int openTfile(const char *Tfilename, uint8_t overwrite, int followup_on_flag, char enabled_extra_data) {
 	int csvfd;
 	char *Tfilename_fileno;
 
@@ -478,8 +478,11 @@ int openTfile(const char *Tfilename,int followup_on_flag, char enabled_extra_dat
 		return -2;
 	}
 
-	csvfd=open(Tfilename, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
-
+	if(overwrite) {
+		csvfd=open(Tfilename, O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR);
+	} else {
+		csvfd=open(Tfilename, O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR);
+	}
 	if(csvfd<0) {
 		if(errno==EEXIST) {
 			// File already exists

--- a/src/udp_client.c
+++ b/src/udp_client.c
@@ -552,7 +552,7 @@ static void *rxLoop_t (void *arg) {
 
 	// Open CSV file when in "-W" mode (i.e. "write every packet measurement data to CSV file")
 	if(args->opts->Wfilename!=NULL) {
-		Wfiledescriptor=openTfile(args->opts->Wfilename,args->opts->followup_mode!=FOLLOWUP_OFF,args->opts->report_extra_data);
+		Wfiledescriptor=openTfile(args->opts->Wfilename,args->opts->overwrite,args->opts->followup_mode!=FOLLOWUP_OFF,args->opts->report_extra_data);
 		if(Wfiledescriptor<0) {
 			fprintf(stderr,"Warning! Cannot open file for writing single packet latency data.\nThe '-W' option will be disabled.\n");
 		}

--- a/src/udp_client_raw.c
+++ b/src/udp_client_raw.c
@@ -619,7 +619,7 @@ static void *rxLoop_t (void *arg) {
 
 	// Open CSV file when in "-W" mode (i.e. "write every packet measurement data to CSV file")
 	if(args->opts->Wfilename!=NULL) {
-		Wfiledescriptor=openTfile(args->opts->Wfilename,args->opts->followup_mode!=FOLLOWUP_OFF,args->opts->report_extra_data);
+		Wfiledescriptor=openTfile(args->opts->Wfilename,args->opts->overwrite,args->opts->followup_mode!=FOLLOWUP_OFF,args->opts->report_extra_data);
 		if(Wfiledescriptor<0) {
 			fprintf(stderr,"Warning! Cannot open file for writing single packet latency data.\nThe '-W' option will be disabled.\n");
 		}

--- a/src/udp_server.c
+++ b/src/udp_server.c
@@ -413,7 +413,7 @@ unsigned int runUDPserver(struct lampsock_data sData, struct options *opts) {
 
 	// Open CSV file when '-W' is specified (as this only applies to the unidirectional mode, no file is create when the mode is not unidirectional)
 	if(opts->Wfilename!=NULL && mode_session==UNIDIR) {
-		Wfiledescriptor=openTfile(opts->Wfilename,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
+		Wfiledescriptor=openTfile(opts->Wfilename,opts->overwrite,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
 		if(Wfiledescriptor<0) {
 			fprintf(stderr,"Warning! Cannot open file for writing single packet latency data.\nThe '-W' option will be disabled.\n");
 		}

--- a/src/udp_server_raw.c
+++ b/src/udp_server_raw.c
@@ -477,7 +477,7 @@ unsigned int runUDPserver_raw(struct lampsock_data sData, macaddr_t srcMAC, stru
 
 	// Open CSV file when '-W' is specified (as this only applies to the unidirectional mode, no file is create when the mode is not unidirectional)
 	if(opts->Wfilename!=NULL && mode_session==UNIDIR) {
-		Wfiledescriptor=openTfile(opts->Wfilename,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
+		Wfiledescriptor=openTfile(opts->Wfilename,opts->overwrite,opts->followup_mode!=FOLLOWUP_OFF,opts->report_extra_data);
 		if(Wfiledescriptor<0) {
 			fprintf(stderr,"Warning! Cannot open file for writing single packet latency data.\nThe '-W' option will be disabled.\n");
 		}


### PR DESCRIPTION
Hi Francesco,
right now there is no possibility to force the overwrite of the CSV file of single packet latency measurements if the file already exists.
The existing option -o, that previously only worked if used together with -f, now also works when used with -W.
Is this something that can be useful to you?